### PR TITLE
Config changes required to support automated cloud builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,35 @@
+version: 3.2_testing_{build}
+branches:
+  only:
+  - El-Capitan
+os: Visual Studio 2015
+configuration:
+- Release (Grey)
+- Release (Black)
+environment:
+  PATH: '%PATH%;C:\Program Files (x86)\nasm'
+install:
+- cmd: >-
+    curl -L -o nasminst.exe http://www.nasm.us/pub/nasm/releasebuilds/2.11.08/win32/nasm-2.11.08-installer.exe
+
+    start /wait nasminst.exe /S
+before_build:
+- cmd: if not %APPVEYOR_REPO_NAME%==Piker-Alpha/macosxbootloader ( cd /d C:\projects\macosxbootloader && git remote add upstream https://github.com/Piker-Alpha/macosxbootloader.git &&  git fetch upstream )
+build:
+  project: src\boot.sln
+  verbosity: normal
+after_build:
+- cmd: >-
+    cd "%APPVEYOR_BUILD_FOLDER%\bin\x86"
+
+    CertUtil -hashfile "%CONFIGURATION%\boot.efi" MD5 > "%CONFIGURATION%\md5.txt"
+
+    if "%CONFIGURATION%"=="Release (Grey)" (set CONFIG=grey)
+
+    if "%CONFIGURATION%"=="Release (Black)" (set CONFIG=black)
+
+    7z a "%APPVEYOR_PROJECT_NAME%_%CONFIG%_%APPVEYOR_BUILD_ID%.zip" "%CONFIGURATION%\boot.efi"
+
+    7z a "%APPVEYOR_PROJECT_NAME%_%CONFIG%_%APPVEYOR_BUILD_ID%.zip" "%CONFIGURATION%\md5.txt"
+
+    appveyor PushArtifact "macosxbootloader_%CONFIG%_%APPVEYOR_BUILD_ID%.zip"

--- a/src/boot.sln
+++ b/src/boot.sln
@@ -1,6 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "boot", "boot\boot.vcxproj", "{70F7FD9D-E4CB-43B3-8A96-43C7E33288CB}"
 	ProjectSection(ProjectDependencies) = postProject
 		{1B43E5F7-D447-4FCF-AC9B-4767AB47DB8B} = {1B43E5F7-D447-4FCF-AC9B-4767AB47DB8B}
@@ -19,6 +21,10 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Win32 = Debug|Win32
 		Debug|x64 = Debug|x64
+		Release (Black)|Win32 = Release (Black)|Win32
+		Release (Black)|x64 = Release (Black)|x64
+		Release (Grey)|Win32 = Release (Grey)|Win32
+		Release (Grey)|x64 = Release (Grey)|x64
 		Release|Win32 = Release|Win32
 		Release|x64 = Release|x64
 	EndGlobalSection
@@ -27,6 +33,14 @@ Global
 		{70F7FD9D-E4CB-43B3-8A96-43C7E33288CB}.Debug|Win32.Build.0 = Debug|Win32
 		{70F7FD9D-E4CB-43B3-8A96-43C7E33288CB}.Debug|x64.ActiveCfg = Debug|x64
 		{70F7FD9D-E4CB-43B3-8A96-43C7E33288CB}.Debug|x64.Build.0 = Debug|x64
+		{70F7FD9D-E4CB-43B3-8A96-43C7E33288CB}.Release (Black)|Win32.ActiveCfg = Release (Black)|Win32
+		{70F7FD9D-E4CB-43B3-8A96-43C7E33288CB}.Release (Black)|Win32.Build.0 = Release (Black)|Win32
+		{70F7FD9D-E4CB-43B3-8A96-43C7E33288CB}.Release (Black)|x64.ActiveCfg = Release (Black)|x64
+		{70F7FD9D-E4CB-43B3-8A96-43C7E33288CB}.Release (Black)|x64.Build.0 = Release (Black)|x64
+		{70F7FD9D-E4CB-43B3-8A96-43C7E33288CB}.Release (Grey)|Win32.ActiveCfg = Release (Grey)|Win32
+		{70F7FD9D-E4CB-43B3-8A96-43C7E33288CB}.Release (Grey)|Win32.Build.0 = Release (Grey)|Win32
+		{70F7FD9D-E4CB-43B3-8A96-43C7E33288CB}.Release (Grey)|x64.ActiveCfg = Release (Grey)|x64
+		{70F7FD9D-E4CB-43B3-8A96-43C7E33288CB}.Release (Grey)|x64.Build.0 = Release (Grey)|x64
 		{70F7FD9D-E4CB-43B3-8A96-43C7E33288CB}.Release|Win32.ActiveCfg = Release|Win32
 		{70F7FD9D-E4CB-43B3-8A96-43C7E33288CB}.Release|Win32.Build.0 = Release|Win32
 		{70F7FD9D-E4CB-43B3-8A96-43C7E33288CB}.Release|x64.ActiveCfg = Release|x64
@@ -35,6 +49,14 @@ Global
 		{1B43E5F7-D447-4FCF-AC9B-4767AB47DB8B}.Debug|Win32.Build.0 = Debug|Win32
 		{1B43E5F7-D447-4FCF-AC9B-4767AB47DB8B}.Debug|x64.ActiveCfg = Debug|x64
 		{1B43E5F7-D447-4FCF-AC9B-4767AB47DB8B}.Debug|x64.Build.0 = Debug|x64
+		{1B43E5F7-D447-4FCF-AC9B-4767AB47DB8B}.Release (Black)|Win32.ActiveCfg = Release|Win32
+		{1B43E5F7-D447-4FCF-AC9B-4767AB47DB8B}.Release (Black)|Win32.Build.0 = Release|Win32
+		{1B43E5F7-D447-4FCF-AC9B-4767AB47DB8B}.Release (Black)|x64.ActiveCfg = Release|x64
+		{1B43E5F7-D447-4FCF-AC9B-4767AB47DB8B}.Release (Black)|x64.Build.0 = Release|x64
+		{1B43E5F7-D447-4FCF-AC9B-4767AB47DB8B}.Release (Grey)|Win32.ActiveCfg = Release|Win32
+		{1B43E5F7-D447-4FCF-AC9B-4767AB47DB8B}.Release (Grey)|Win32.Build.0 = Release|Win32
+		{1B43E5F7-D447-4FCF-AC9B-4767AB47DB8B}.Release (Grey)|x64.ActiveCfg = Release|x64
+		{1B43E5F7-D447-4FCF-AC9B-4767AB47DB8B}.Release (Grey)|x64.Build.0 = Release|x64
 		{1B43E5F7-D447-4FCF-AC9B-4767AB47DB8B}.Release|Win32.ActiveCfg = Release|Win32
 		{1B43E5F7-D447-4FCF-AC9B-4767AB47DB8B}.Release|Win32.Build.0 = Release|Win32
 		{1B43E5F7-D447-4FCF-AC9B-4767AB47DB8B}.Release|x64.ActiveCfg = Release|x64

--- a/src/boot/StdAfx.h
+++ b/src/boot/StdAfx.h
@@ -18,9 +18,13 @@
 #define TARGET_OS															EL_CAPITAN
 
 #if (TARGET_OS >= YOSEMITE)
+#ifndef LEGACY_GREY_SUPPORT
 	#define LEGACY_GREY_SUPPORT												1
+#endif
 #else
+#ifndef LEGACY_GREY_SUPPORT
 	#define LEGACY_GREY_SUPPORT												0
+#endif
 #endif
 
 #define PATCH_LOAD_EXECUTABLE												1

--- a/src/boot/boot.vcxproj
+++ b/src/boot/boot.vcxproj
@@ -9,6 +9,22 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Release (Black)|Win32">
+      <Configuration>Release (Black)</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release (Black)|x64">
+      <Configuration>Release (Black)</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release (Grey)|Win32">
+      <Configuration>Release (Grey)</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release (Grey)|x64">
+      <Configuration>Release (Grey)</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
       <Platform>Win32</Platform>
@@ -36,7 +52,23 @@
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release (Black)|Win32'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release (Grey)|Win32'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release (Black)|x64'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release (Grey)|x64'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
@@ -58,7 +90,27 @@
     <Import Project="..\common.props" />
     <Import Project="..\release.props" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release (Black)|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\common.props" />
+    <Import Project="..\release.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release (Grey)|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\common.props" />
+    <Import Project="..\release.props" />
+  </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\common.props" />
+    <Import Project="..\release.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release (Black)|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\common.props" />
+    <Import Project="..\release.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release (Grey)|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="..\common.props" />
     <Import Project="..\release.props" />
@@ -73,9 +125,41 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <TargetExt>.efi</TargetExt>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release (Black)|Win32'">
+    <TargetExt>.efi</TargetExt>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release (Grey)|Win32'">
+    <TargetExt>.efi</TargetExt>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <TargetExt>.efi</TargetExt>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release (Black)|x64'">
+    <TargetExt>.efi</TargetExt>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release (Grey)|x64'">
+    <TargetExt>.efi</TargetExt>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release (Black)|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>LEGACY_GREY_SUPPORT=0;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release (Grey)|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>LEGACY_GREY_SUPPORT=1;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release (Black)|x64'">
+    <ClCompile>
+      <PreprocessorDefinitions>LEGACY_GREY_SUPPORT=0;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release (Grey)|x64'">
+    <ClCompile>
+      <PreprocessorDefinitions>LEGACY_GREY_SUPPORT=1;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="AcpiUtils.h" />
     <ClInclude Include="Base64.h" />
@@ -135,10 +219,14 @@
     <ClCompile Include="x64\ArchUtilsX64.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release (Black)|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release (Grey)|Win32'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="x64\DebuggerUtilsX64.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release (Black)|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release (Grey)|Win32'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="BootDebugger.cpp" />
     <ClCompile Include="Crc32.cpp" />
@@ -156,38 +244,60 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release (Black)|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release (Grey)|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release (Black)|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release (Grey)|x64'">Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="x86\ArchUtilsX86.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release (Black)|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release (Grey)|x64'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="x86\CompilerX86.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release (Black)|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release (Grey)|x64'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="x86\DebuggerUtilsX86.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release (Black)|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release (Grey)|x64'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="x86\Thunk64.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release (Black)|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release (Grey)|x64'">true</ExcludedFromBuild>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="x64\CompilerX64.asm">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release (Black)|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release (Grey)|Win32'">true</ExcludedFromBuild>
       <FileType>Document</FileType>
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">cd "%(RootDir)%(Directory)" &amp; nasm -o "$(IntDir)%(Filename).obj" -f win64 -X vc "%(FullPath)"</Command>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">cd "%(RootDir)%(Directory)" &amp; nasm -o "$(IntDir)%(Filename).obj" -f win64 -X vc "%(FullPath)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release (Black)|x64'">cd "%(RootDir)%(Directory)" &amp; nasm -o "$(IntDir)%(Filename).obj" -f win64 -X vc "%(FullPath)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release (Grey)|x64'">cd "%(RootDir)%(Directory)" &amp; nasm -o "$(IntDir)%(Filename).obj" -f win64 -X vc "%(FullPath)"</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)%(Filename).obj;%(Outputs)</Outputs>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">%(RootDir)%(Directory)/Common.inc;%(AdditionalInputs)</AdditionalInputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)%(Filename).obj;%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release (Black)|x64'">$(IntDir)%(Filename).obj;%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release (Grey)|x64'">$(IntDir)%(Filename).obj;%(Outputs)</Outputs>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">%(RootDir)%(Directory)/Common.inc;%(AdditionalInputs)</AdditionalInputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release (Black)|x64'">%(RootDir)%(Directory)/Common.inc;%(AdditionalInputs)</AdditionalInputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release (Grey)|x64'">%(RootDir)%(Directory)/Common.inc;%(AdditionalInputs)</AdditionalInputs>
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">%(Identity)</Message>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">%(Identity)</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release (Black)|x64'">%(Identity)</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release (Grey)|x64'">%(Identity)</Message>
     </CustomBuild>
   </ItemGroup>
   <ItemGroup>
@@ -197,10 +307,18 @@
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)%(Filename).obj;%(Outputs)</Outputs>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">%(RootDir)%(Directory)/Common.inc;%(AdditionalInputs)</AdditionalInputs>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">%(RootDir)%(Directory)/Common.inc;%(AdditionalInputs)</AdditionalInputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release (Black)|x64'">%(RootDir)%(Directory)/Common.inc;%(AdditionalInputs)</AdditionalInputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release (Grey)|x64'">%(RootDir)%(Directory)/Common.inc;%(AdditionalInputs)</AdditionalInputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)%(Filename).obj;%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release (Black)|x64'">$(IntDir)%(Filename).obj;%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release (Grey)|x64'">$(IntDir)%(Filename).obj;%(Outputs)</Outputs>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">cd "%(RootDir)%(Directory)" &amp; nasm -o "$(IntDir)%(Filename).obj" -f win64 -X vc "%(FullPath)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release (Black)|x64'">cd "%(RootDir)%(Directory)" &amp; nasm -o "$(IntDir)%(Filename).obj" -f win64 -X vc "%(FullPath)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release (Grey)|x64'">cd "%(RootDir)%(Directory)" &amp; nasm -o "$(IntDir)%(Filename).obj" -f win64 -X vc "%(FullPath)"</Command>
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">%(Identity)</Message>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">%(Identity)</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release (Black)|x64'">%(Identity)</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release (Grey)|x64'">%(Identity)</Message>
     </CustomBuild>
   </ItemGroup>
   <ItemGroup>
@@ -208,12 +326,20 @@
       <FileType>Document</FileType>
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">cd "%(RootDir)%(Directory)" &amp; nasm -o "$(IntDir)%(Filename).obj" -f win64 -X vc "%(FullPath)"</Command>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">cd "%(RootDir)%(Directory)" &amp; nasm -o "$(IntDir)%(Filename).obj" -f win64 -X vc "%(FullPath)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release (Black)|x64'">cd "%(RootDir)%(Directory)" &amp; nasm -o "$(IntDir)%(Filename).obj" -f win64 -X vc "%(FullPath)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release (Grey)|x64'">cd "%(RootDir)%(Directory)" &amp; nasm -o "$(IntDir)%(Filename).obj" -f win64 -X vc "%(FullPath)"</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)%(Filename).obj;%(Outputs)</Outputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)%(Filename).obj;%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release (Black)|x64'">$(IntDir)%(Filename).obj;%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release (Grey)|x64'">$(IntDir)%(Filename).obj;%(Outputs)</Outputs>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">%(RootDir)%(Directory)/Common.inc;%(AdditionalInputs)</AdditionalInputs>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">%(RootDir)%(Directory)/Common.inc;%(AdditionalInputs)</AdditionalInputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release (Black)|x64'">%(RootDir)%(Directory)/Common.inc;%(AdditionalInputs)</AdditionalInputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release (Grey)|x64'">%(RootDir)%(Directory)/Common.inc;%(AdditionalInputs)</AdditionalInputs>
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">%(Identity)</Message>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">%(Identity)</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release (Black)|x64'">%(Identity)</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release (Grey)|x64'">%(Identity)</Message>
     </CustomBuild>
   </ItemGroup>
   <ItemGroup>
@@ -221,12 +347,20 @@
       <FileType>Document</FileType>
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">cd "%(RootDir)%(Directory)" &amp; nasm -o "$(IntDir)%(Filename).obj" -f win64 -X vc "%(FullPath)"</Command>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">cd "%(RootDir)%(Directory)" &amp; nasm -o "$(IntDir)%(Filename).obj" -f win64 -X vc "%(FullPath)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release (Black)|x64'">cd "%(RootDir)%(Directory)" &amp; nasm -o "$(IntDir)%(Filename).obj" -f win64 -X vc "%(FullPath)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release (Grey)|x64'">cd "%(RootDir)%(Directory)" &amp; nasm -o "$(IntDir)%(Filename).obj" -f win64 -X vc "%(FullPath)"</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)%(Filename).obj;%(Outputs)</Outputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)%(Filename).obj;%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release (Black)|x64'">$(IntDir)%(Filename).obj;%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release (Grey)|x64'">$(IntDir)%(Filename).obj;%(Outputs)</Outputs>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">%(RootDir)%(Directory)/Common.inc;%(AdditionalInputs)</AdditionalInputs>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">%(RootDir)%(Directory)/Common.inc;%(AdditionalInputs)</AdditionalInputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release (Black)|x64'">%(RootDir)%(Directory)/Common.inc;%(AdditionalInputs)</AdditionalInputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release (Grey)|x64'">%(RootDir)%(Directory)/Common.inc;%(AdditionalInputs)</AdditionalInputs>
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">%(Identity)</Message>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">%(Identity)</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release (Black)|x64'">%(Identity)</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release (Grey)|x64'">%(Identity)</Message>
     </CustomBuild>
   </ItemGroup>
   <ItemGroup>
@@ -234,21 +368,35 @@
       <FileType>Document</FileType>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)ThunkCode64.dat;%(AdditionalInputs)</AdditionalInputs>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)ThunkCode64.dat;%(AdditionalInputs)</AdditionalInputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release (Black)|Win32'">$(IntDir)ThunkCode64.dat;%(AdditionalInputs)</AdditionalInputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release (Grey)|Win32'">$(IntDir)ThunkCode64.dat;%(AdditionalInputs)</AdditionalInputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)%(Filename).obj;%(Outputs)</Outputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)%(Filename).obj;%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release (Black)|Win32'">$(IntDir)%(Filename).obj;%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release (Grey)|Win32'">$(IntDir)%(Filename).obj;%(Outputs)</Outputs>
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">cd "$(IntDir)" &amp; nasm -o "$(IntDir)%(Filename).obj" -fwin32 -X vc "%(FullPath)"</Command>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">cd "$(IntDir)" &amp; nasm -o "$(IntDir)%(Filename).obj" -fwin32 -X vc "%(FullPath)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release (Black)|Win32'">cd "$(IntDir)" &amp; nasm -o "$(IntDir)%(Filename).obj" -fwin32 -X vc "%(FullPath)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release (Grey)|Win32'">cd "$(IntDir)" &amp; nasm -o "$(IntDir)%(Filename).obj" -fwin32 -X vc "%(FullPath)"</Command>
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">%(Identity)</Message>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">%(Identity)</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release (Black)|Win32'">%(Identity)</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release (Grey)|Win32'">%(Identity)</Message>
     </CustomBuild>
     <CustomBuild Include="x86\ThunkCode64.asm">
       <FileType>Document</FileType>
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">cd "%(RootDir)%(Directory)" &amp; nasm -o "$(IntDir)%(Filename).dat"  -X vc "%(FullPath)"</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)%(Filename).dat;%(Outputs)</Outputs>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">cd "%(RootDir)%(Directory)" &amp; nasm -o "$(IntDir)%(Filename).dat"  -X vc "%(FullPath)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release (Black)|Win32'">cd "%(RootDir)%(Directory)" &amp; nasm -o "$(IntDir)%(Filename).dat"  -X vc "%(FullPath)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release (Grey)|Win32'">cd "%(RootDir)%(Directory)" &amp; nasm -o "$(IntDir)%(Filename).dat"  -X vc "%(FullPath)"</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)%(Filename).dat;%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release (Black)|Win32'">$(IntDir)%(Filename).dat;%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release (Grey)|Win32'">$(IntDir)%(Filename).dat;%(Outputs)</Outputs>
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">%(Identity)</Message>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">%(Identity)</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release (Black)|Win32'">%(Identity)</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release (Grey)|Win32'">%(Identity)</Message>
     </CustomBuild>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Hiya Pike,

This is clawfinger from the macrumor.com forums. It looks like things have gone quiet in the developer thread right now.  I hope you are taking that much needed (and deserved) rest.  Once you are back at, working on the things laid out in  [Post #639](http://forums.macrumors.com/threads/boot-efi-developers-thread.1924434/page-26#post-22137162) I assume, I've taken the liberty of setting up automated cloud based builds for the repo via AppVeyor, the only CIS site that provides Windows hosts.  The good news is, it's completely free for Open Source projects and is more than sufficient for our needs.  This way we will have one set of reference builds for everyone to draw from, including for Releases, and nobody has to mess with manual builds anymore (especially you).

First I added two additional configs to the Solution: 'Release (Grey)' and 'Release (Black)'.  I left the old 'Release' alone just in case.  This did require a very minor change to StdAfx.h to allow me to use the preprocessor to set the LEGACY_GREY_SUPPORT #define (I hope I got it right).  It could probably be cleaned up better for non El-Capitan but for now that is obviously our focus.  I also have it generating 'md5.txt' files for each boot.efi for every build.

I've set it up so it sets your repo as upstream for forks (such as mine), but not if it detects it is running out of your base repo (the 'before_build' section of the YAML below).  Currently I have this up and running [here](https://ci.appveyor.com/project/JeremyMiller/macosxbootloader) but obviously builds won't trigger when you commit to your repo.  I've created a script called 'runBuild' that contains my API key that I can send you in case you don't want to mess with setting this up yourself.

Alternatively, if you'd like to set this up directly out of your repo, it's just a few easy steps:

1) Accept Pull Request which includes already configured 'appVeyor.yml' file in root of project
2) Create an AppVeyor account [here](https://ci.appveyor.com/signup) making sure to select for the Plan: "FREE - for open-source projects"
3) Click "New Project", Select "GitHub" -> Select "Public repositories only" -> Click "Authorize GitHub" -> Log into GitHub and grant access to AppVeyor
4) Hover over "macosxbootloader" and click "+ADD" to the right
5) Click ">NEW BUILD" in the upper right

That should do it!  Now a new build will be triggered on every new checkin, and we can just direct people to a URL such as: https://ci.appveyor.com/project/Piker-Alpha/macosxbootloader to grab binaries.

Note: I haven't actually had the opportunity to verify these builds work on actual hardware, however they seem to diff alright with known working builds.

Thanks,

-Jeremy (clawfinger)
